### PR TITLE
Handle palette images with translucency

### DIFF
--- a/src/amulet/resource_pack/java/resource_pack_manager.py
+++ b/src/amulet/resource_pack/java/resource_pack_manager.py
@@ -152,7 +152,9 @@ class JavaResourcePackManager(BaseResourcePackManager[JavaResourcePack]):
                                 alpha = numpy.array(im.getchannel("A").getdata())
                                 texture_is_transparent = bool(numpy.any(alpha != 255))
                             elif im.mode == "P":
-                                texture_is_transparent = im.info.get("transparency", 0) != 0
+                                texture_is_transparent = (
+                                    im.info.get("transparency", 0) != 0
+                                )
                             else:
                                 texture_is_transparent = False
 

--- a/src/amulet/resource_pack/java/resource_pack_manager.py
+++ b/src/amulet/resource_pack/java/resource_pack_manager.py
@@ -151,6 +151,8 @@ class JavaResourcePackManager(BaseResourcePackManager[JavaResourcePack]):
                             if im.mode == "RGBA":
                                 alpha = numpy.array(im.getchannel("A").getdata())
                                 texture_is_transparent = bool(numpy.any(alpha != 255))
+                            elif im.mode == "P":
+                                texture_is_transparent = im.info.get("transparency", 0) != 0
                             else:
                                 texture_is_transparent = False
 


### PR DESCRIPTION
Images with transparency stored in the palette format were assumed opaque